### PR TITLE
HTREPO-91: strip whitespace from page labels

### DIFF
--- a/lib/epub/metadata_extractor.rb
+++ b/lib/epub/metadata_extractor.rb
@@ -7,10 +7,9 @@ require "digest"
 module EPUB
   # Extracts metadata from an epub in the form needed for meta.yml
   class MetadataExtractor
-    def initialize(epub_path)
+    def initialize(epub_path, epub = Parser.parse(epub_path))
       @epub_path = epub_path
-
-      @epub = Parser.parse(epub_path)
+      @epub = epub
     end
 
     def metadata
@@ -26,13 +25,13 @@ module EPUB
       epub.spine.items.map {|item| item.content_document.read }
     end
 
-    private
-
     def pagedata
       epub.manifest.nav.content_document.navigation.items.map do |x|
-        [x.item.full_path.to_s, { "label" => x.text }]
+        [x.item.full_path.to_s, { "label" => x.text.strip }]
       end.to_h
     end
+
+    private
 
     def epub_contents
       # for each... filename, checksum, mimetype, size, created

--- a/lib/epub/sip_writer.rb
+++ b/lib/epub/sip_writer.rb
@@ -3,6 +3,7 @@
 require "html_reader"
 require "epub/metadata_extractor"
 require "epub/zip_file_writer"
+require "yaml"
 
 module EPUB
   # Given an epub, generates a HathiTrust SIP


### PR DESCRIPTION
Testing this in a reasonable way isn't easy since the internals of how
we get metadata from the epub are tied into the metadata extractor.
Longer term we should probably add a seam between whatever gets metadata
from the epub and what formats that into the output metadata, which will
make this easier to test.