### PR TITLE
HTREPO-97: serialize times as strings

### DIFF
--- a/lib/epub/metadata_extractor.rb
+++ b/lib/epub/metadata_extractor.rb
@@ -5,6 +5,8 @@ require "epub/parser"
 require "digest"
 
 module EPUB
+  ISO8601_XSD_DATETIME="%FT%T%:z"
+
   # Extracts metadata from an epub in the form needed for meta.yml
   class MetadataExtractor
     def initialize(epub_path, epub = Parser.parse(epub_path))
@@ -14,7 +16,7 @@ module EPUB
 
     def metadata
       {
-        "creation_date"  => Time.parse("2017-12-06 08:06:00-05:00"),
+        "creation_date"  => Time.parse("2017-12-06 08:06:00-05:00").strftime(ISO8601_XSD_DATETIME),
         "creation_agent" => "umich",
         "epub_contents"  => epub_contents,
         "pagedata"       => pagedata.to_h
@@ -49,7 +51,7 @@ module EPUB
           "checksum" => Digest::MD5.new.update(entry.get_input_stream.read).hexdigest,
           "mimetype" => mimetype,
           "size"     => entry.size,
-          "created"  => entry.time }
+          "created"  => entry.time.strftime(ISO8601_XSD_DATETIME) }
       end
     end
 

--- a/spec/epub/metadata_extractor_spec.rb
+++ b/spec/epub/metadata_extractor_spec.rb
@@ -3,6 +3,7 @@
 require "spec_helper"
 require "epub/metadata_extractor"
 require "yaml"
+require "pry"
 
 require_relative "./fixtures"
 
@@ -12,7 +13,7 @@ RSpec.describe EPUB::MetadataExtractor do
       include_context "with simple epub fixtures"
       subject { described_class.new(simple_epub) }
 
-      let(:meta_yml) { YAML.safe_load(File.read("#{fixture}/meta.yml"), [Time]) }
+      let(:meta_yml) { YAML.safe_load(File.read("#{fixture}/meta.yml")) }
 
       def compare_metadata_part(finder)
         expect(finder.call(subject.metadata)).to eql(finder.call(meta_yml))
@@ -35,7 +36,7 @@ RSpec.describe EPUB::MetadataExtractor do
       context "with an epub #{basename}.epub with hierarchy in the toc or dirs" do
         let(:fixtures) { File.dirname(__FILE__) + "/../support/fixtures" }
         let(:epub) { "#{fixtures}/#{basename}.epub" }
-        let(:meta_yml) { YAML.safe_load(File.read("#{fixtures}/#{basename}_meta.yml"), [Time]) }
+        let(:meta_yml) { YAML.safe_load(File.read("#{fixtures}/#{basename}_meta.yml")) }
 
         subject { described_class.new(epub) }
 

--- a/spec/support/fixtures/ark+=87302=t00000001/meta.yml
+++ b/spec/support/fixtures/ark+=87302=t00000001/meta.yml
@@ -1,4 +1,4 @@
-creation_date: 2017-12-06T09:06:00-04:00
+creation_date: "2017-12-06T08:06:00-05:00"
 creation_agent: umich
 
 epub_contents:
@@ -10,21 +10,21 @@ epub_contents:
       # made up
       mimetype: application/xml  
       size: 239
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
   mimetype:
     - filename: mimetype
       checksum: 4154e1f4f9c0e002cc44aae97103ebe2
       # made up
       mimetype: text/plain    
       size: 20
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
   rootfile:
     - filename: OEBPS/content.opf
       checksum: 31447aba266a1c2918d8c2ee0698ef61
       # from container.xml
       mimetype: application/oebps-package+xml 
       size: 2584
-      created: 2017-12-05 15:58:30.000000000 -05:00
+      created: "2017-12-05T15:58:30-05:00"
   manifest:
     # keep files in the order they were in in the manifest (not sure it matters
     # for anything, but might as well preserve the ordering)
@@ -32,37 +32,37 @@ epub_contents:
       checksum: 57b388186ba815f372537bfba8bf500e
       mimetype: application/x-dtbncx+xml
       size: 1029
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
     - filename: OEBPS/toc.xhtml
       checksum: 3d9defd76447ffe2bf88c9ed3093d2ae
       mimetype: application/xhtml+xml
       size: 762
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
     - filename: OEBPS/style.css
       checksum: 26863d0ac59ed4bacdeffaf62b102808
       mimetype: text/css
       size: 6643
-      created: 2017-12-05 15:58:09.000000000 -05:00
+      created: "2017-12-05T15:58:09-05:00"
     - filename: OEBPS/0_no-title.xhtml
       checksum: fe665af3bfddabaf1837e46e12057e9d
       mimetype: application/xhtml+xml    # from content.opf manifest
       size: 337
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
     - filename: OEBPS/1_no-title.xhtml
       checksum: fe1535d9c820f33dac8278ef05760ee4
       mimetype: application/xhtml+xml
       size: 860
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
     - filename: OEBPS/2_chapter-1.xhtml
       checksum: b46505d4c242e9cc5f7bc7e20d8f0bf4
       mimetype: application/xhtml+xml
       size: 531
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
     - filename: OEBPS/3_chapter-2.xhtml
       checksum: 715ed5c3ff6c577c211c5c6ae7aa51d2
       mimetype: application/xhtml+xml
       size: 503
-      created: 2017-12-05 20:55:40.000000000 -05:00
+      created: "2017-12-05T20:55:40-05:00"
   spine:
     # provide filenames relative to the root of the epub (not ids)
     # should be 00000001.txt

--- a/spec/support/fixtures/nested_dirs_meta.yml
+++ b/spec/support/fixtures/nested_dirs_meta.yml
@@ -1,5 +1,5 @@
 ---
-creation_date: 2017-12-06 08:06:00.000000000 -05:00
+creation_date: "2017-12-06T08:06:00-05:00"
 creation_agent: umich
 epub_contents:
   rootfile:
@@ -7,35 +7,35 @@ epub_contents:
     checksum: 6cb76894dedfc24fe0132aca8badfa3b
     mimetype: application/oebps-package+xml
     size: 1852
-    created: 2018-01-12 09:37:09.000000000 -05:00
+    created: "2018-01-12T09:37:09-05:00"
   container:
   - filename: META-INF/container.xml
     checksum: 824c2ce6c9013f5353bbfe6598e6b372
     mimetype: application/xml
     size: 257
-    created: 2018-01-12 09:22:26.000000000 -05:00
+    created: "2018-01-12T09:22:26-05:00"
   mimetype:
   - filename: mimetype
     checksum: 4154e1f4f9c0e002cc44aae97103ebe2
     mimetype: text/plain
     size: 20
-    created: 2017-12-05 20:55:40.000000000 -05:00
+    created: "2017-12-05 20:55:40-05:00"
   manifest:
   - filename: nested/dir/toc.ncx
     checksum: 797e48d1e5e4cb0abeb12b53e72af3b2
     mimetype: application/x-dtbncx+xml
     size: 694
-    created: 2018-01-12 09:39:46.000000000 -05:00
+    created: "2018-01-12T09:39:46-05:00"
   - filename: nested/dir/text/toc.xhtml
     checksum: bc75aafa0796b561e1d1bb87fe06fe81
     mimetype: application/xhtml+xml
     size: 544
-    created: 2018-01-12 09:38:01.000000000 -05:00
+    created: "2018-01-12T09:38:01-05:00"
   - filename: nested/dir/text/2_chapter-1.xhtml
     checksum: e5d0d60ed4d2f7b595a4a2645df9ce6c
     mimetype: application/xhtml+xml
     size: 471
-    created: 2018-01-12 09:37:34.000000000 -05:00
+    created: "2018-01-12T09:37:34-05:00"
   spine:
   - nested/dir/text/toc.xhtml
   - nested/dir/text/2_chapter-1.xhtml

--- a/spec/support/fixtures/nested_dirs_traversal_meta.yml
+++ b/spec/support/fixtures/nested_dirs_traversal_meta.yml
@@ -1,5 +1,5 @@
 ---
-creation_date: 2017-12-06 08:06:00.000000000 -05:00
+creation_date: "2017-12-06T08:06:00-05:00"
 creation_agent: umich
 epub_contents:
   rootfile:
@@ -7,35 +7,35 @@ epub_contents:
     checksum: 6cb76894dedfc24fe0132aca8badfa3b
     mimetype: application/oebps-package+xml
     size: 1852
-    created: 2018-01-12 09:37:09.000000000 -05:00
+    created: "2018-01-12T09:37:09-05:00"
   container:
   - filename: META-INF/container.xml
     checksum: 824c2ce6c9013f5353bbfe6598e6b372
     mimetype: application/xml
     size: 257
-    created: 2018-01-12 09:22:26.000000000 -05:00
+    created: "2018-01-12T09:22:26-05:00"
   mimetype:
   - filename: mimetype
     checksum: 4154e1f4f9c0e002cc44aae97103ebe2
     mimetype: text/plain
     size: 20
-    created: 2017-12-05 20:55:40.000000000 -05:00
+    created: 2017-12-05 20:55:40-05:00"
   manifest:
   - filename: nested/dir/toc.ncx
     checksum: 797e48d1e5e4cb0abeb12b53e72af3b2
     mimetype: application/x-dtbncx+xml
     size: 694
-    created: 2018-01-12 09:39:46.000000000 -05:00
+    created: "2018-01-12T09:39:46-05:00"
   - filename: nested/dir/text/toc.xhtml
     checksum: bf5fc7354c81e20952739801469e40ba
     mimetype: application/xhtml+xml
     size: 552
-    created: 2018-01-12 12:05:23.000000000 -05:00
+    created: "2018-01-12T12:05:23-05:00"
   - filename: nested/dir/text/2_chapter-1.xhtml
     checksum: e5d0d60ed4d2f7b595a4a2645df9ce6c
     mimetype: application/xhtml+xml
     size: 471
-    created: 2018-01-12 09:37:34.000000000 -05:00
+    created: "2018-01-12T09:37:34-05:00"
   spine:
   - nested/dir/text/toc.xhtml
   - nested/dir/text/2_chapter-1.xhtml

--- a/spec/support/fixtures/test_nested_meta.yml
+++ b/spec/support/fixtures/test_nested_meta.yml
@@ -1,5 +1,5 @@
 ---
-creation_date: 2017-12-06 08:06:00.000000000 -05:00
+creation_date: "2017-12-06T08:06:00-05:00"
 creation_agent: umich
 epub_contents:
   rootfile:
@@ -7,70 +7,70 @@ epub_contents:
     checksum: c3eeb6231a50589d8d54ed450dc60e31
     mimetype: application/oebps-package+xml
     size: 3114
-    created: 2018-01-11 13:27:57.000000000 -05:00
+    created: "2018-01-11T13:27:57-05:00"
   container:
   - filename: META-INF/container.xml
     checksum: bc793f50d0ec7ff556193c109f5d3afc
     mimetype: application/xml
     size: 239
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   mimetype:
   - filename: mimetype
     checksum: 4154e1f4f9c0e002cc44aae97103ebe2
     mimetype: text/plain
     size: 20
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   manifest:
   - filename: OEBPS/toc.ncx
     checksum: 589880004d5bd2bcb6b30b5ce9e9eaa3
     mimetype: application/x-dtbncx+xml
     size: 1825
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/toc.xhtml
     checksum: 03711ea9f0c3a2499bcd6e18458d90ac
     mimetype: application/xhtml+xml
     size: 1404
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/style.css
     checksum: c2e885ccf27a3e2ce7645686cb98aecd
     mimetype: text/css
     size: 6821
-    created: 2018-01-11 13:28:17.000000000 -05:00
+    created: "2018-01-11T13:28:17-05:00"
   - filename: OEBPS/0_no-title.xhtml
     checksum: fe665af3bfddabaf1837e46e12057e9d
     mimetype: application/xhtml+xml
     size: 337
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/1_no-title.xhtml
     checksum: b5ec670af20b75ad215260030a5a5e22
     mimetype: application/xhtml+xml
     size: 860
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/2_part-one.xhtml
     checksum: 3b45e7fa9d8bcb4ad13d6edf665c835d
     mimetype: application/xhtml+xml
     size: 407
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/3_chapter-1.xhtml
     checksum: b46505d4c242e9cc5f7bc7e20d8f0bf4
     mimetype: application/xhtml+xml
     size: 531
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/4_chapter-2.xhtml
     checksum: 715ed5c3ff6c577c211c5c6ae7aa51d2
     mimetype: application/xhtml+xml
     size: 503
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/5_part-two.xhtml
     checksum: bcdebe92d2626d591c2bae0b53f422df
     mimetype: application/xhtml+xml
     size: 408
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   - filename: OEBPS/6_chapter-3.xhtml
     checksum: ee2a1b56b21519466af8cb7fd5b02048
     mimetype: application/xhtml+xml
     size: 467
-    created: 2018-01-11 18:23:24.000000000 -05:00
+    created: "2018-01-11T18:23:24-05:00"
   spine:
   - OEBPS/0_no-title.xhtml
   - OEBPS/1_no-title.xhtml


### PR DESCRIPTION
expect strings will be serialized to the iso8601 xsd:datetime format to
meta.yml

the perl yaml library downstream doesn't do any special time parsing
anyway - it basically just expects these to be treated as strings anyway
- so this behavior is better than being forced into dealing with ruby
Time objects in the yaml